### PR TITLE
add fallback for output and cwd are the same folder

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -28,8 +28,11 @@ export default async function runVrt({
 
     // Copy files to result first
     fs.copySync(path.resolve(__dirname, 'report-assets'), path.resolve(output));
-    fs.copySync(path.resolve(cwd, 'baseline'), dirs.baseline);
-    fs.copySync(path.resolve(cwd, 'test'), dirs.test);
+
+    if (output !== cwd) {
+        fs.copySync(path.resolve(cwd, 'baseline'), dirs.baseline);
+        fs.copySync(path.resolve(cwd, 'test'), dirs.test);
+    }
 
     // Collect images from baseline and testing paths
     try {


### PR DESCRIPTION
for most of our instance output folder for images and report-resources is the same folder - I added fallback for this scenario in order to support existing builds.