### PR TITLE
Fix types and default values validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magiclab/vrt-runner",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "VRT runner and result generator for images",
   "main": "build/index.js",
   "repository": "https://github.com/badoo/vrt-runner",

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -1,32 +1,33 @@
 #!/usr/bin/env node
 
-import { argv } from 'yargs';
+import yargs from 'yargs';
 import path from 'path';
 import runVrt from './index';
 
-const cwd = (argv.cwd as string) || process.cwd();
-const output = (argv.output as string) || path.resolve(cwd, 'result');
-const teamcity = !!argv.teamcity;
-// higher then 0.05 will cause a fail
-const matchingThreshold = (argv.matchingThreshold as number) || 0.05;
-const thresholdRate = argv.thresholdRate as number | undefined;
-const thresholdPixel = argv.thresholdPixel as number | undefined;
-const enableAntialias = (argv.enableAntialias as boolean) || true;
-const additionalDetection = argv.additionalDetection as boolean | undefined;
-const concurrency = argv.concurrency as number | undefined;
-const ignoreChange = (argv.ignoreChange as boolean) || true;
+const { cwd, output, teamcity, _, $0, ...options } = yargs(process.argv.slice(2))
+    .options({
+        cwd: { type: 'string', demandOption: true, default: process.cwd() },
+        output: {
+            type: 'string',
+            demandOption: true,
+            default: path.resolve(process.cwd(), 'output'),
+        },
+        teamcity: { type: 'string', default: false },
+        // higher then 0.05 will cause a fail
+        matchingThreshold: { type: 'number', default: 0.05 },
+        thresholdRate: { type: 'number' },
+        thresholdPixel: { type: 'number' },
+        enableAntialias: { type: 'boolean', default: true },
+        additionalDetection: { type: 'boolean' },
+        concurrency: { type: 'number' },
+        ignoreChange: { type: 'boolean', default: true },
+    })
+    .strict()
+    .parserConfiguration({ 'camel-case-expansion': false }).argv;
 
 runVrt({
     cwd,
     output,
     teamcity,
-    options: {
-        matchingThreshold,
-        thresholdRate,
-        thresholdPixel,
-        enableAntialias,
-        additionalDetection,
-        concurrency,
-        ignoreChange,
-    },
+    options,
 });

--- a/src/compare.ts
+++ b/src/compare.ts
@@ -50,6 +50,7 @@ async function diffDirs({ output, dirs, teamcity, options }: diffDirsType) {
         [dirs.test, dirs.baseline, dirs.diff, `--json=${vrtCommandReportFile}`, ...flags],
         {
             stdout: process.stdout,
+            preferLocal: true,
         }
     );
 


### PR DESCRIPTION
This is the only correct way of type checking. We have to use Yargs parser methods like `options` and `strict`.
I'm destructuring from `argv` utility keys `_` and `$0` to assign the rest of vrt flags to `options`. 